### PR TITLE
upgrade to base image to fixed CVE-2019-15847

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13-alpine
+FROM node:14.11.0-alpine3.12
 
 # ARG is used here to make auto-update easy
 ARG version=0.30.0


### PR DESCRIPTION
when i scan this image using the Vulnerability Scanner trivy i got a CVE-2019-15847MEDIUM issue into libgcc and libstdc++ version 9.2.0-r4