### PR TITLE
Add trivy check to container build

### DIFF
--- a/.github/workflows/build_test_tag.yml
+++ b/.github/workflows/build_test_tag.yml
@@ -12,13 +12,12 @@ jobs:
     - name: Run image
       run: docker run image
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.0.14
       with:
         image-ref: 'image'
         format: 'table'
         exit-code: '1'
         ignore-unfixed: true
-        vuln-type: 'os,library'
 
   tag:
     needs: build_test

--- a/.github/workflows/build_test_tag.yml
+++ b/.github/workflows/build_test_tag.yml
@@ -11,6 +11,14 @@ jobs:
       run: docker build . --file Dockerfile --tag image
     - name: Run image
       run: docker run image
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: 'image'
+        format: 'table'
+        exit-code: '1'
+        ignore-unfixed: true
+        vuln-type: 'os,library'
 
   tag:
     needs: build_test

--- a/.github/workflows/build_test_tag.yml
+++ b/.github/workflows/build_test_tag.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Run image
       run: docker run image
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@v0.0.14
+      uses: aquasecurity/trivy-action@0.0.14
       with:
         image-ref: 'image'
         format: 'table'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.11.0-alpine3.12
+FROM node:15.14-alpine3.13
 
 # ARG is used here to make auto-update easy
 ARG version=0.42.0


### PR DESCRIPTION
As a result of https://github.com/jamescooke/openapi-validator-docker/pull/45 , I've been concerned that node / alpine images used to ship this container image might have security issues. I'm not manually scanning the built images with Trivy, and it should not be expected that consumers of this image will check / report issues.

Instead, this adds a Trivy check on the built container using https://github.com/marketplace/actions/aqua-security-trivy

This build on current master shows that the current node container `node:14.11.0-alpine3.12` has vulnerabilities: https://github.com/jamescooke/openapi-validator-docker/runs/2361482722 - so this PR also bumps the container.