### PR TITLE
Bump to node 17, adjust update.sh to work with new tag format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.9-alpine3.14
+FROM node:17.2-alpine3.14
 
 # ARG is used here to make auto-update easy
 ARG version=0.52.0


### PR DESCRIPTION
## Changes

* Bumps to node 17. This also provides a new version of alpine to fix the Trivy errors here https://github.com/jamescooke/openapi-validator-docker/runs/4576376239?check_suite_focus=true#step:6:23
* Adjust `update.sh` to work with new `ibm-openapi-validator@X.Y.Z` format tags: https://github.com/IBM/openapi-validator/releases/tag/ibm-openapi-validator%400.52.0