### PR TITLE
Revert to main repo for release-info-action

### DIFF
--- a/.github/workflows/create_pr_for_release.yml
+++ b/.github/workflows/create_pr_for_release.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Get latest openapi-validator tag
       id: latest_tag
-      uses: jamescooke/release-info-action@1e086647a869e733d22a2ccffe0377d6267038bc
+      uses: abatilo/release-info-action@1.3.1
       with:
         owner: IBM
         repo: openapi-validator


### PR DESCRIPTION
Now that https://github.com/abatilo/release-info-action/issues/11 is fixed, can use main repo again.