### PR TITLE
Bump underlying node image to node:current (move to debian from alpine)

### DIFF
--- a/.github/workflows/build_test_tag.yml
+++ b/.github/workflows/build_test_tag.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Run image
       run: docker run image
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.3.0
+      uses: aquasecurity/trivy-action@0.5.1
       with:
         image-ref: 'image'
         format: 'table'

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ARG version=0.81.1
 
 RUN npm install -g ibm-openapi-validator@${version}
 
+RUN npm cache clean --force
+
 WORKDIR /data
 
 ENTRYPOINT ["lint-openapi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.3-alpine3.15
+FROM node:18.5-alpine3.16
 
 # ARG is used here to make auto-update easy
 ARG version=0.81.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.5-alpine3.16
+FROM node:current
 
 # ARG is used here to make auto-update easy
 ARG version=0.81.1


### PR DESCRIPTION
Fixes #176 