### PR TITLE
Remove npm cache after install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ARG version=0.81.1
 
 RUN npm install -g ibm-openapi-validator@${version}
 
+RUN npm cache clean --force
+
 WORKDIR /data
 
 ENTRYPOINT ["lint-openapi"]


### PR DESCRIPTION
This change removes the file that triggers the error listed in #173. The cache shouldn't be needed after the npm install has completed.

Fixes #173