### PR TITLE
Install openapi-ruleset in image

### DIFF
--- a/.github/workflows/build_test_tag.yml
+++ b/.github/workflows/build_test_tag.yml
@@ -10,10 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
     - name: Build image
       run: docker build . --file Dockerfile --tag image
+
     - name: Run image
+      # Smoke test image by simply calling it directly with no file to check
       run: docker run image
+
+    - name: Run image against test spec
+      run: docker run --volume "$PWD/test":/data image simple.yaml
+
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.5.1
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM node:current-alpine3.16
 
+WORKDIR /data
+
 # ARG is used here to make auto-update easy
 ARG version=0.96.1
 
 RUN npm install -g ibm-openapi-validator@${version}
 
 RUN npm cache clean --force
-
-WORKDIR /data
 
 ENTRYPOINT ["lint-openapi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ RUN npm install -g ibm-openapi-validator@${version}
 
 RUN npm cache clean --force
 
+RUN npm install @ibm-cloud/openapi-ruleset
+
 ENTRYPOINT ["lint-openapi"]

--- a/test/.spectral.yaml
+++ b/test/.spectral.yaml
@@ -1,0 +1,3 @@
+extends: '@ibm-cloud/openapi-ruleset'
+rules:
+  oas3-schema: off

--- a/test/simple.yaml
+++ b/test/simple.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Minimal test schema
+  description: Contains a single error - the get request does not contain a response body.
+  version: "1.0"
+servers:
+  - url: https://example.com/api/v3
+paths:
+  /test:
+    get:
+      operationId: get_test
+      tags:
+        - test
+      description: Get information about a test.
+      summary: That test you wrote, get it
+tags:
+  - name: test


### PR DESCRIPTION
Fixes #200 , related to https://github.com/IBM/openapi-validator/issues/354

## Adds

* Add test step to validate a simple schema `test/simple.yaml` with a single error, but with a `.spectral.yaml` file to ignore the error. Failing run in Actions is here: https://github.com/jamescooke/openapi-validator-docker/actions/runs/3357056292/jobs/5562608341#step:6:5

  ```
  '/data/@ibm-cloud/openapi-ruleset' is imported by .spectral.js, but could not be resolved – treating it as an external dependency

  errors

    Message :   "get" property must have required property "responses".
    Path    :   paths./test.get
    Line    :   10
  ```