### PR TITLE
Bump image, adjust test

### DIFF
--- a/.github/workflows/build_test_tag.yml
+++ b/.github/workflows/build_test_tag.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Build image
       run: docker build . --file Dockerfile --tag image
     - name: Run image
-      run: docker run image
+      run: docker run image --version
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.5.1
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-alpine3.16
+FROM node:current-alpine3.17
 
 # ARG is used here to make auto-update easy
 ARG version=1.0.1


### PR DESCRIPTION
## Changes

* Base image bumped from alpine 3.16 to alpine 3.17.
* Calling validator without any args now returns status 2 error - previously this was 0. Have added `--version` which returns 0.