### PR TITLE
Switch to container off alpine to avoid vuln

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-buster
+FROM node:current-bullseye
 
 # ARG is used here to make auto-update easy
 ARG version=1.0.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-alpine3.17
+FROM node:current-buster
 
 # ARG is used here to make auto-update easy
 ARG version=1.0.4


### PR DESCRIPTION
Until https://github.com/alpinelinux/docker-alpine/issues/321 is resolved upstream.

This is to avoid shipping a container that does not pass trivy.